### PR TITLE
Changed lstar unit in example to meters

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -51,7 +51,7 @@ A typical configuration file looks like the following::
     MW 18.9
     gamma 2.31
     # Geometric parameters
-    lstar 40
+    lstar 1.016
     area_ratio 5.5
 
 

--- a/openrocketengine/core/test_config.cfg
+++ b/openrocketengine/core/test_config.cfg
@@ -12,5 +12,5 @@ MR 2.1
 MW 18.9
 gamma 2.31
 # Geometric parameters
-lstar 40
+lstar 1.016
 area_ratio 5.5


### PR DESCRIPTION
It looks like the lstar unit in the example is still in inches because an lstar of 40 meters gives a chamber length of 7 meters which is huge. If it is supposed to be 40 meters than you can just close this PR.